### PR TITLE
Docker support (Tested on RTX3080) + ignoring reproducable files / cache

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+models/
+Dockerfile
+README.md
+LICENSE
+assets/
+*.egg-info

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+models/ldm/text2img-large/
+outputs/
+src/
+__pycache__/
+*.egg-info

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+FROM nvidia/cuda:11.3.1-cudnn8-devel-ubuntu20.04
+MAINTAINER Peter Willemsen <peter@codebuffet.co>
+RUN echo "Installing dependencies..." && \
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y curl wget sudo git build-essential cmake pkg-config liblzma-dev libbz2-dev zlib1g-dev libssl-dev zsh clang && \
+    apt-get dist-upgrade -y && \
+	rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src/python
+RUN wget https://www.python.org/ftp/python/3.8.5/Python-3.8.5.tgz -O python-src.tar.gz && \
+    tar xzvf python-src.tar.gz --strip-components=1 && \
+    rm python-src.tar.gz && \
+    ./configure --enable-optimizations --prefix=/opt/python-3.8.5 && \
+    make && \
+    make install && \
+    rm -rf /src/python
+WORKDIR / 
+ENV PATH="/opt/python-3.8.5/bin:${PATH}"
+
+RUN python3 -m pip install pip==20.3
+RUN pip3 install torch==1.10.1+cu113 -f https://download.pytorch.org/whl/cu113/torch_stable.html
+RUN pip3 install numpy==1.19.2 torchvision==0.11.2 albumentations==0.4.3 opencv-python==4.1.2.30 pudb==2019.2 imageio==2.9.0 imageio-ffmpeg==0.4.2 pytorch-lightning==1.6.1 omegaconf==2.1.1 test-tube>=0.7.5 streamlit>=0.73.1 einops==0.3.0 torch-fidelity==0.3.0 transformers==4.3.1 -e "git+https://github.com/CompVis/taming-transformers.git@master#egg=taming-transformers" -e "git+https://github.com/openai/CLIP.git@main#egg=clip"
+
+RUN mkdir -p /opt/ldm_package
+ADD ./setup.py /opt/ldm_package
+ADD ./ldm /opt/ldm_package/ldm
+ADD ./configs /opt/ldm_package/configs
+RUN pip3 install -e /opt/ldm_package
+
+WORKDIR /opt/ldm
+
+# Add dev user
+RUN useradd -ms /bin/zsh ldm-dev && \
+    usermod -aG sudo ldm-dev && \
+    echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+USER ldm-dev
+
+ENTRYPOINT ["python3"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,38 +1,27 @@
-FROM nvidia/cuda:11.3.1-cudnn8-devel-ubuntu20.04
+FROM nvcr.io/nvidia/pytorch:22.04-py3
 MAINTAINER Peter Willemsen <peter@codebuffet.co>
-RUN echo "Installing dependencies..." && \
-    apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y curl wget sudo git build-essential cmake pkg-config liblzma-dev libbz2-dev zlib1g-dev libssl-dev zsh clang && \
-    apt-get dist-upgrade -y && \
-	rm -rf /var/lib/apt/lists/*
 
-WORKDIR /src/python
-RUN wget https://www.python.org/ftp/python/3.8.5/Python-3.8.5.tgz -O python-src.tar.gz && \
-    tar xzvf python-src.tar.gz --strip-components=1 && \
-    rm python-src.tar.gz && \
-    ./configure --enable-optimizations --prefix=/opt/python-3.8.5 && \
-    make && \
-    make install && \
-    rm -rf /src/python
-WORKDIR / 
-ENV PATH="/opt/python-3.8.5/bin:${PATH}"
-
-RUN python3 -m pip install pip==20.3
-RUN pip3 install torch==1.10.1+cu113 -f https://download.pytorch.org/whl/cu113/torch_stable.html
-RUN pip3 install numpy==1.19.2 torchvision==0.11.2 albumentations==0.4.3 opencv-python==4.1.2.30 pudb==2019.2 imageio==2.9.0 imageio-ffmpeg==0.4.2 pytorch-lightning==1.6.1 omegaconf==2.1.1 test-tube>=0.7.5 streamlit>=0.73.1 einops==0.3.0 torch-fidelity==0.3.0 transformers==4.3.1 -e "git+https://github.com/CompVis/taming-transformers.git@master#egg=taming-transformers" -e "git+https://github.com/openai/CLIP.git@main#egg=clip"
+RUN conda
 
 RUN mkdir -p /opt/ldm_package
-ADD ./setup.py /opt/ldm_package
-ADD ./ldm /opt/ldm_package/ldm
-ADD ./configs /opt/ldm_package/configs
-RUN pip3 install -e /opt/ldm_package
+COPY ./setup.py /opt/ldm_package
+COPY ./ldm /opt/ldm_package/ldm
+COPY ./configs /opt/ldm_package/configs
+COPY environment.yaml /opt/ldm_package
+
+# For the ldm-dev user
+RUN chmod 777 -R /opt/ldm_package
 
 WORKDIR /opt/ldm
 
 # Add dev user
-RUN useradd -ms /bin/zsh ldm-dev && \
+RUN useradd -ms /bin/bash ldm-dev && \
     usermod -aG sudo ldm-dev && \
     echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 USER ldm-dev
 
-ENTRYPOINT ["python3"]
+RUN conda env create -f /opt/ldm_package/environment.yaml
+RUN pip3 install -e /opt/ldm_package
+RUN conda run -n ldm pip install pytorch-lightning==1.5
+
+ENTRYPOINT ["conda", "run", "-n", "ldm"]

--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ Faster sampling (i.e. even lower values of `ddim_steps`) while retaining good qu
 
 ## Installing on Docker
 
-- Note: depending on CUDA/GPU version, you might have to change the first line in te Dockerfile or change the torch version being installed. 
 - Build the image: `docker build . --tag latent-diffusion`
 - For text-to-image, download the pre-trained weights (5.7GB):
   ```
@@ -73,7 +72,7 @@ Faster sampling (i.e. even lower values of `ddim_steps`) while retaining good qu
   ```
 - Sample with (Make sure to call in the directory of this repo):
   ```
-  docker run --name=tmp-diffusion --rm --gpus all -it -v "$(pwd):/opt/ldm" latent-diffusion /opt/ldm/scripts/txt2img.py --prompt "A large blue whale on a freight ship, vector art" --ddim_eta 0.0 --n_samples 4 --n_iter 4 --scale 5.0 --ddim_steps 50
+  docker run --name=tmp-diffusion --rm --gpus all -it -v "$(pwd):/opt/ldm" latent-diffusion python /opt/ldm/scripts/txt2img.py --prompt "A large blue whale on a freight ship, vector art" --ddim_eta 0.0 --n_samples 4 --n_iter 4 --scale 5.0 --ddim_steps 50
   ```
 
 #### Beyond 256²

--- a/README.md
+++ b/README.md
@@ -58,6 +58,20 @@ As a rule of thumb, higher values of `scale` produce better samples at the cost 
 Furthermore, increasing `ddim_steps` generally also gives higher quality samples, but returns are diminishing for values > 250.
 Fast sampling (i.e. low values of `ddim_steps`) while retaining good quality can be achieved by using `--ddim_eta 0.0`.  
 
+## Installing on Docker
+
+- Note: depending on CUDA/GPU version, you might have to change the first line in te Dockerfile or change the torch version being installed. 
+- Build the image: `docker build . --tag latent-diffusion`
+- For text-to-image, download the pre-trained weights (5.7GB):
+  ```
+  mkdir -p models/ldm/text2img-large/
+  wget -O models/ldm/text2img-large/model.ckpt https://ommer-lab.com/files/latent-diffusion/nitro/txt2img-f8-large/model.ckpt
+  ```
+- Sample with (Make sure to call in the directory of this repo):
+  ```
+  docker run --name=tmp-diffusion --rm --gpus all -it -v "$(pwd):/opt/ldm" latent-diffusion /opt/ldm/scripts/txt2img.py --prompt "A large blue whale on a freight ship, vector art" --ddim_eta 0.0 --n_samples 4 --n_iter 4 --scale 5.0 --ddim_steps 50
+  ```
+
 #### Beyond 256²
 
 For certain inputs, simply running the model in a convolutional fashion on larger features than it was trained on


### PR DESCRIPTION
# Intro

I added support for Docker, and made sure cache and build files do not hit the repository, making it easier to work for others on this.

The Docker image downloads Python from source and uses optimized compilation making sure for max possible speed. It replicates the Conda environment and gives easier access for others as well as deploying this to servers!

I added a clause in the README explaining how to install the software on Docker.

Also offers a fix for #49 (this issue won't appear on Docker)

Tested on:
 - Tuxedo Stellaris 15 (AMD Ryzen 9 5900HX - 32GB RAM - RTX 3080 16GB)

## "A large blue whale on a freight ship, vector art"

![A-large-blue-whale-on-a-freight-ship,-vector-art](https://user-images.githubusercontent.com/1212814/163564070-a62c18ff-d6b7-4cfc-83c3-317aecc38ae3.png)
