### PR TITLE
Update environment file with new dependencies

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -15,6 +15,8 @@ dependencies:
     - pudb==2019.2
     - imageio==2.9.0
     - imageio-ffmpeg==0.4.2
+    - kornia==0.6.6
+    - torchmetrics==v0.6.0
     - pytorch-lightning==1.4.2
     - omegaconf==2.1.1
     - test-tube>=0.7.5


### PR DESCRIPTION
Updating the environment.yaml to resolve errors encountered while trying to follow the README instructions for the txt2img.py script

The `torchmetrics==v0.6.0` change fixes this error: (Note there is already an open PR for this [here](https://github.com/CompVis/latent-diffusion/pull/109))
```
00:05 $ python scripts/txt2img.py --prompt "a virus monster is playing guitar, oil on canvas" --ddim_eta 0.0 --n_samples 4 --n_iter 4 --scale 5.0  --ddim_steps 50
Loading model from models/ldm/text2img-large/model.ckpt
Traceback (most recent call last):
  File "scripts/txt2img.py", line 108, in <module>
    model = load_model_from_config(config, "models/ldm/text2img-large/model.ckpt")  # TODO: check path
  File "scripts/txt2img.py", line 19, in load_model_from_config
    model = instantiate_from_config(config.model)
  File "/home/adam/Development/aistuff/latent-diffusion/ldm/util.py", line 85, in instantiate_from_config
    return get_obj_from_str(config["target"])(**config.get("params", dict()))
  File "/home/adam/Development/aistuff/latent-diffusion/ldm/util.py", line 93, in get_obj_from_str
    return getattr(importlib.import_module(module, package=None), cls)
  File "/home/adam/miniconda3/envs/ldm/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 783, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/home/adam/Development/aistuff/latent-diffusion/ldm/models/diffusion/ddpm.py", line 12, in <module>
    import pytorch_lightning as pl
  File "/home/adam/miniconda3/envs/ldm/lib/python3.8/site-packages/pytorch_lightning/__init__.py", line 20, in <module>
    from pytorch_lightning import metrics  # noqa: E402
  File "/home/adam/miniconda3/envs/ldm/lib/python3.8/site-packages/pytorch_lightning/metrics/__init__.py", line 15, in <module>
    from pytorch_lightning.metrics.classification import (  # noqa: F401
  File "/home/adam/miniconda3/envs/ldm/lib/python3.8/site-packages/pytorch_lightning/metrics/classification/__init__.py", line 14, in <module>
    from pytorch_lightning.metrics.classification.accuracy import Accuracy  # noqa: F401
  File "/home/adam/miniconda3/envs/ldm/lib/python3.8/site-packages/pytorch_lightning/metrics/classification/accuracy.py", line 18, in <module>
    from pytorch_lightning.metrics.utils import deprecated_metrics, void
  File "/home/adam/miniconda3/envs/ldm/lib/python3.8/site-packages/pytorch_lightning/metrics/utils.py", line 22, in <module>
    from torchmetrics.utilities.data import get_num_classes as _get_num_classes
ImportError: cannot import name 'get_num_classes' from 'torchmetrics.utilities.data' (/home/adam/miniconda3/envs/ldm/lib/python3.8/site-packages/torchmetrics/utilities/data.py)
```

The `kornia==0.6.6` fixes this error: (dependency introduced [here](https://github.com/CompVis/latent-diffusion/pull/111))
```
00:11 $ python scripts/txt2img.py --prompt "a virus monster is playing guitar, oil on canvas" --ddim_eta 0.0 --n_samples 4 --n_iter 4 --scale 5.0  --ddim_steps 50
Loading model from models/ldm/text2img-large/model.ckpt
LatentDiffusion: Running in eps-prediction mode
DiffusionWrapper has 872.30 M params.
making attention of type 'vanilla' with 512 in_channels
Working with z of shape (1, 4, 32, 32) = 4096 dimensions.
making attention of type 'vanilla' with 512 in_channels
/home/adam/Development/aistuff/latent-diffusion/src/clip/clip/clip.py:24: UserWarning: PyTorch version 1.7.1 or higher is recommended
  warnings.warn("PyTorch version 1.7.1 or higher is recommended")
Traceback (most recent call last):
  File "scripts/txt2img.py", line 108, in <module>
    model = load_model_from_config(config, "models/ldm/text2img-large/model.ckpt")  # TODO: check path
  File "scripts/txt2img.py", line 19, in load_model_from_config
    model = instantiate_from_config(config.model)
  File "/home/adam/Development/aistuff/latent-diffusion/ldm/util.py", line 85, in instantiate_from_config
    return get_obj_from_str(config["target"])(**config.get("params", dict()))
  File "/home/adam/Development/aistuff/latent-diffusion/ldm/models/diffusion/ddpm.py", line 461, in __init__
    self.instantiate_cond_stage(cond_stage_config)
  File "/home/adam/Development/aistuff/latent-diffusion/ldm/models/diffusion/ddpm.py", line 527, in instantiate_cond_stage
    model = instantiate_from_config(config)
  File "/home/adam/Development/aistuff/latent-diffusion/ldm/util.py", line 85, in instantiate_from_config
    return get_obj_from_str(config["target"])(**config.get("params", dict()))
  File "/home/adam/Development/aistuff/latent-diffusion/ldm/util.py", line 93, in get_obj_from_str
    return getattr(importlib.import_module(module, package=None), cls)
  File "/home/adam/miniconda3/envs/ldm/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 783, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/home/adam/Development/aistuff/latent-diffusion/ldm/modules/encoders/modules.py", line 6, in <module>
    import kornia
ModuleNotFoundError: No module named 'kornia'
```