### PR TITLE
rank_zero_only from correct module

### DIFF
--- a/ldm/models/diffusion/ddpm.py
+++ b/ldm/models/diffusion/ddpm.py
@@ -16,7 +16,7 @@ from contextlib import contextmanager
 from functools import partial
 from tqdm import tqdm
 from torchvision.utils import make_grid
-from pytorch_lightning.utilities.distributed import rank_zero_only
+from pytorch_lightning.utilities.rank_zero import rank_zero_only
 
 from ldm.util import log_txt_as_img, exists, default, ismap, isimage, mean_flat, count_params, instantiate_from_config
 from ldm.modules.ema import LitEma


### PR DESCRIPTION
Fixes `ModuleNotFoundError: No module named 'pytorch_lightning.utilities.distributed'`

`pytorch_lightning.utilities.distributed` is obsolete.
