### PR TITLE
make it possible to run in cpu

### DIFF
--- a/ldm/modules/encoders/modules.py
+++ b/ldm/modules/encoders/modules.py
@@ -84,7 +84,7 @@ class BERTEmbedder(AbstractEncoder):
         super().__init__()
         self.use_tknz_fn = use_tokenizer
         if self.use_tknz_fn:
-            self.tknz_fn = BERTTokenizer(vq_interface=False, max_length=max_seq_len)
+            self.tknz_fn = BERTTokenizer(device=device,vq_interface=False, max_length=max_seq_len)
         self.device = device
         self.transformer = TransformerWrapper(num_tokens=vocab_size, max_seq_len=max_seq_len,
                                               attn_layers=Encoder(dim=n_embed, depth=n_layer),


### PR DESCRIPTION
I passed "device=device" when instantiating BERTTokenizer in BERTEmbedder, allowing inference to be performed on the CPU.

In the original code, tokens will be moved to "device" after tokenized. Without this edit, tokens will be moved to GPU by default, which makes it impossible to run on the CPU when we need to do it (for example, when we have insufficient GPU memory).